### PR TITLE
[S2Geometry] Bump version to 0.11.1 and bump OpenSSL compat

### DIFF
--- a/S/S2Geometry/build_tarballs.jl
+++ b/S/S2Geometry/build_tarballs.jl
@@ -26,7 +26,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms(; exclude=p -> !((Sys.islinux(p) || Sys.isapple(p)) && nbits(p) == 64))
+platforms = supported_platforms(; exclude=p -> !(nbits(p) == 64))
 platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built


### PR DESCRIPTION
From their README it seems you can build s2geometry with OpenSSL v3.x, so I've updated that as well.